### PR TITLE
Chore: print error information when ImportError arises.

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -60,9 +60,9 @@ class LazyLiteLLM:
             ):
                 self._lazy_module._logging._disable_debugging()
 
-        except ImportError:
+        except ImportError as e:
             print(
-                "Error: litellm not found. Please install it: pip install litellm",
+                f"Error: {e} litellm not found. Please install it: pip install litellm",
                 file=sys.stderr,
             )
             sys.exit(1)


### PR DESCRIPTION
出现 ImportError 时，可能不是 litellm 缺失引起的。需要打印更多的信息。

例如，我的 Emacs 使用了 SOCKS 代理，可能由于 socksio 包缺失，导致 ImportError 错误。

Error: Using SOCKS proxy, but the 'socksio' package is not installed. Make sure to install httpx using `pip install httpx[socks]`. litellm not found. Please install it: pip install litellm
