### PR TITLE
Chore: Convert prompt to no properties.

### DIFF
--- a/emigo.el
+++ b/emigo.el
@@ -266,6 +266,7 @@ Then Emigo will start by gdb, please send new issue with `*emigo*' buffer conten
 
 (defun emigo (prompt)
   (interactive "sEmigo: ")
+  (setq prompt (substring-no-properties prompt))
   (if (boundp 'emigo--project-path)
       (emigo-call-async "emigo_project" emigo--project-path prompt)
     (emigo-call-async "emigo" (buffer-file-name) prompt)))


### PR DESCRIPTION
When calling emigo like this `(emigo (thing-at-point 'word)))`, the passed argument is a string with properties, which will result in an error:

deferred error : (error "\"TypeError('emigo() takes 3 positional arguments but 4 were given')\"")

通过 elisp 调用 emigo 函数，无法传入包含属性的字符串。会报错。因此在 emigo 把属性去掉。 