### PR TITLE
Fix path compare on windows, unify path separator before compare

### DIFF
--- a/session.py
+++ b/session.py
@@ -87,7 +87,7 @@ class Session:
 
             if not os.path.isfile(abs_path):
                  return False, f"File not found: {rel_filename}"
-            if not abs_path.startswith(self.session_path):
+            if not abs_path.startswith(os.path.abspath(self.session_path)):
                  return False, f"File is outside session directory: {rel_filename}"
 
             # Add to context if not already present


### PR DESCRIPTION
修复：windows上add_file_to_context无法添加文件。

windows上正、反斜线都能用，abspath返回的统一到\，可用于对比。


顺便提个建议，项目中会有很多文件、路径操作，`os.path` 改成 `pathlib` (py3.4+) 更方便些