### PR TITLE
Fix straight config in README to install Python sources too

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The project is at its early-stage. Expect frequent breaking changes and unstable
 
     ```emacs-lisp
     (use-package emigo
-      :straight (:host github :repo "MatthewZMD/emigo")
+      :straight (:host github :repo "MatthewZMD/emigo" :files (:defaults "*.py" "*.el"))
       :config
       (emigo-enable) ;; Starts the background process automatically
       :custom


### PR DESCRIPTION
As discussed in https://github.com/MatthewZMD/emigo/issues/10#issuecomment-2817667584.

I figured that I'd do this over `:files ("*")` since that would copy a bunch of unused files like the README, images, etc.